### PR TITLE
도메인 업데이트: UserAccount 회원 ID에 유니크 키 추가

### DIFF
--- a/src/main/java/alpacaive/projectboard/domain/UserAccount.java
+++ b/src/main/java/alpacaive/projectboard/domain/UserAccount.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 @Getter
 @ToString
 @Table(indexes = {
-        @Index(columnList = "userId"),
+        @Index(columnList = "userId", unique = true),
         @Index(columnList = "email", unique = true),
         @Index(columnList = "createdAt"),
         @Index(columnList = "createdBy")

--- a/src/test/java/alpacaive/projectboard/repository/JpaRepositoryTest.java
+++ b/src/test/java/alpacaive/projectboard/repository/JpaRepositoryTest.java
@@ -52,7 +52,7 @@ class JpaRepositoryTest {
     void give_when_then2() {
         // given
         long previousCount = articleRepository.count();
-        UserAccount userAccount = userAccountRepository.save(UserAccount.of("Zeus", "pw", null, null, null));
+        UserAccount userAccount = userAccountRepository.save(UserAccount.of("newZeus", "pw", null, null, null));
         Article article = Article.of(userAccount, "new article", "new content", "#spring");
 
         // when


### PR DESCRIPTION
회원 id로 로그인하고 유저 식별하므로, 당연히 uk 여야 한다.
이 부분이 설계에서 반영되지 않았던 것을 발견
테스트는 uk 적용으로 기존 `data.sql` 의 테스트 데이터와 중복이 발생하므로 `userId` 이름을 수정

This closes #27 